### PR TITLE
ライセンスヘッダの追加

### DIFF
--- a/config/license/header.txt
+++ b/config/license/header.txt
@@ -1,0 +1,16 @@
+Copyright (C) 2025 TeamVoxelOdyssey
+
+This file is part of VoxelOdysseyPlugins.
+
+VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.

--- a/vo-core/build.gradle.kts
+++ b/vo-core/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("java-library")
     id("io.papermc.paperweight.userdev") version "2.0.0-beta.16"
+    id("com.github.hierynomus.license") version "0.16.1"
 }
 
 group = "com.guy7cc"
@@ -29,6 +30,13 @@ java {
     if (JavaVersion.current() < JavaVersion.toVersion(targetJavaVersion)) {
         toolchain.languageVersion.set(JavaLanguageVersion.of(targetJavaVersion))
     }
+}
+
+license {
+    header = file("$rootDir/config/license/header.txt")
+    exclude("**/*")
+    include("**/*.java")
+    mapping("java", "SLASHSTAR_STYLE")
 }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/VOCorePlugin.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/VOCorePlugin.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core;
 
 import org.bukkit.Bukkit;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/VoxelOdysseyCore.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/VoxelOdysseyCore.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core;
 
 import com.guy7cc.voxelodyssey.core.command.CommandManager;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/BooleanArg.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/BooleanArg.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.command;
 
 import org.jetbrains.annotations.Nullable;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/CommandArg.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/CommandArg.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.command;
 
 import com.guy7cc.voxelodyssey.core.item.VOItem;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/CommandComposition.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/CommandComposition.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.command;
 
 import org.bukkit.command.Command;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/CommandDescriptor.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/CommandDescriptor.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.command;
 
 import org.bukkit.command.CommandExecutor;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/CommandManager.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/CommandManager.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.command;
 
 import com.guy7cc.voxelodyssey.core.common.ExecutionOrder;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/LiteralArg.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/LiteralArg.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.command;
 
 import org.jetbrains.annotations.Nullable;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/RangedDoubleArg.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/RangedDoubleArg.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.command;
 
 import org.jetbrains.annotations.Nullable;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/RangedFloatArg.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/RangedFloatArg.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.command;
 
 import org.jetbrains.annotations.Nullable;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/RangedIntegerArg.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/RangedIntegerArg.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.command;
 
 import org.jetbrains.annotations.Nullable;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/RangedLongArg.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/RangedLongArg.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.command;
 
 import org.jetbrains.annotations.Nullable;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/RegistryArg.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/RegistryArg.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.command;
 
 import com.guy7cc.voxelodyssey.core.registry.Key;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/VOItemArg.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/VOItemArg.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.command;
 
 import com.guy7cc.voxelodyssey.core.item.VOCoreItems;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/VOItemCommand.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/command/VOItemCommand.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.command;
 
 import com.guy7cc.voxelodyssey.core.VoxelOdysseyCore;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/AbstractWrapper.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/AbstractWrapper.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.common;
 
 public class AbstractWrapper<T> implements Wrapper<T> {

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/Copyable.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/Copyable.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.common;
 
 public interface Copyable<T> extends Cloneable {

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/ExecutionOrder.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/ExecutionOrder.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.common;
 
 import java.lang.annotation.ElementType;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/GeneralEventHandler.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/GeneralEventHandler.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.common;
 
 import com.guy7cc.voxelodyssey.core.util.ReflectionUtil;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/GeneralPluginLifecycleHandler.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/GeneralPluginLifecycleHandler.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.common;
 
 import com.guy7cc.voxelodyssey.core.util.ReflectionUtil;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/GeneralTicker.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/GeneralTicker.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.common;
 
 import com.guy7cc.voxelodyssey.core.util.ReflectionUtil;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/PluginLifecycleListener.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/PluginLifecycleListener.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.common;
 
 import org.bukkit.plugin.java.JavaPlugin;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/ScoreboardContainer.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/ScoreboardContainer.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.common;
 
 import org.bukkit.Bukkit;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/SneakyThrower.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/SneakyThrower.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 /**
  * This code is based on the following source. I sincerely appreciate it.
  * https://qiita.com/myui/items/6597087d6a0648ca1dec

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/ThrowingConsumer.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/ThrowingConsumer.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 /**
  * This code is based on the following source. I sincerely appreciate it.
  * https://qiita.com/myui/items/6597087d6a0648ca1dec

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/Tickable.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/Tickable.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.common;
 
 import java.util.Collection;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/Wrapper.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/Wrapper.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.common;
 
 public interface Wrapper<T> {

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/WrapperContainer.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/common/WrapperContainer.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.common;
 
 import java.util.Collection;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/data/DataFormatException.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/data/DataFormatException.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.data;
 
 public class DataFormatException extends Exception {

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/data/DataHolder.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/data/DataHolder.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.data;
 
 import com.google.gson.JsonObject;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/data/DataLoader.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/data/DataLoader.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.data;
 
 import com.google.gson.JsonElement;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/data/InvalidDataReason.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/data/InvalidDataReason.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.data;
 
 import java.io.File;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/data/JsonFileIO.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/data/JsonFileIO.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.data;
 
 import com.google.gson.*;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/data/JsonObjectWrapper.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/data/JsonObjectWrapper.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.data;
 
 import com.google.gson.JsonArray;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/data/JsonSerializable.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/data/JsonSerializable.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.data;
 
 import com.google.gson.JsonElement;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/data/UuidAdapter.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/data/UuidAdapter.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.data;
 
 import com.google.gson.TypeAdapter;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/entity/VOCoreEntityTypes.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/entity/VOCoreEntityTypes.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.entity;
 
 import com.guy7cc.voxelodyssey.core.VOCorePlugin;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/entity/VOEntity.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/entity/VOEntity.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.entity;
 
 import com.guy7cc.voxelodyssey.core.common.Tickable;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/entity/VOEntityFactoryArgs.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/entity/VOEntityFactoryArgs.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.entity;
 
 public class VOEntityFactoryArgs {

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/entity/VOEntityManager.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/entity/VOEntityManager.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.entity;
 
 import com.google.gson.JsonElement;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/entity/VOEntityType.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/entity/VOEntityType.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.entity;
 
 import com.guy7cc.voxelodyssey.core.registry.AbstractRegistryObject;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/entity/player/NoOpVOPlayer.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/entity/player/NoOpVOPlayer.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.entity.player;
 
 import com.google.gson.JsonElement;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/entity/player/VOPlayer.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/entity/player/VOPlayer.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.entity.player;
 
 import com.guy7cc.voxelodyssey.core.data.JsonSerializable;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/actionbar/ActionBarBridge.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/actionbar/ActionBarBridge.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.gui.actionbar;
 
 import com.guy7cc.voxelodyssey.core.common.Tickable;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/actionbar/ActionBarBridgeImpl.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/actionbar/ActionBarBridgeImpl.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.gui.actionbar;
 
 import org.bukkit.entity.Player;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/actionbar/ActionBarComponent.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/actionbar/ActionBarComponent.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.gui.actionbar;
 
 import com.guy7cc.voxelodyssey.core.common.Tickable;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/actionbar/CooltimeComponent.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/actionbar/CooltimeComponent.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.gui.actionbar;
 
 import com.guy7cc.voxelodyssey.core.item.CoolDown;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/menu/MenuComponent.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/menu/MenuComponent.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.gui.menu;
 
 import org.bukkit.event.inventory.InventoryClickEvent;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/menu/MenuInventory.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/menu/MenuInventory.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.gui.menu;
 
 import com.guy7cc.voxelodyssey.core.common.AbstractWrapper;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/menu/MenuInventoryProperty.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/menu/MenuInventoryProperty.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.gui.menu;
 
 import net.kyori.adventure.text.Component;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/sidebar/SidebarBridge.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/sidebar/SidebarBridge.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.gui.sidebar;
 
 import com.guy7cc.voxelodyssey.core.common.Tickable;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/sidebar/SidebarBridgeImpl.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/sidebar/SidebarBridgeImpl.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.gui.sidebar;
 
 import com.guy7cc.voxelodyssey.core.VoxelOdysseyCore;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/sidebar/SidebarComponent.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/sidebar/SidebarComponent.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.gui.sidebar;
 
 import com.guy7cc.voxelodyssey.core.common.Tickable;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/sidebar/SimpleSidebarComponent.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/sidebar/SimpleSidebarComponent.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.gui.sidebar;
 
 import java.util.Collection;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/title/CharWidth.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/title/CharWidth.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.gui.title;
 
 import org.jetbrains.annotations.NotNull;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/title/TitleBridge.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/title/TitleBridge.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.gui.title;
 
 import com.guy7cc.voxelodyssey.core.common.Tickable;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/title/TitleBridgeImpl.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/title/TitleBridgeImpl.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.gui.title;
 
 import org.bukkit.entity.Player;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/title/TitleComponent.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/title/TitleComponent.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.gui.title;
 
 import com.guy7cc.voxelodyssey.core.common.Tickable;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/title/TitlePosition.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/gui/title/TitlePosition.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.gui.title;
 
 public enum TitlePosition {

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/item/CoolDown.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/item/CoolDown.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.item;
 
 import com.google.gson.JsonArray;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/item/CoolDownHolder.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/item/CoolDownHolder.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.item;
 
 public interface CoolDownHolder {

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/item/VOCoreItems.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/item/VOCoreItems.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.item;
 
 import com.guy7cc.voxelodyssey.core.VOCorePlugin;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/item/VOItem.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/item/VOItem.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.item;
 
 import com.guy7cc.voxelodyssey.core.registry.AbstractRegistryObject;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/item/VOItemInteractionResult.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/item/VOItemInteractionResult.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.item;
 
 public enum VOItemInteractionResult {

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/item/VOItemStackWrapper.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/item/VOItemStackWrapper.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.item;
 
 import com.google.gson.JsonElement;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/item/VOItemUsage.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/item/VOItemUsage.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.item;
 
 import java.util.Locale;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/AbstractProperty.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/AbstractProperty.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.property;
 
 import com.guy7cc.voxelodyssey.core.registry.AbstractRegistryObject;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/AbstractState.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/AbstractState.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.property;
 
 import com.google.gson.JsonElement;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/DoubleProperty.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/DoubleProperty.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.property;
 
 import com.google.gson.JsonElement;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/ImmutableValueHolder.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/ImmutableValueHolder.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.property;
 
 import com.guy7cc.voxelodyssey.core.VoxelOdysseyCore;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/IntegerProperty.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/IntegerProperty.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.property;
 
 import com.google.gson.JsonElement;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/JsonSerializableProperty.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/JsonSerializableProperty.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.property;
 
 import com.google.gson.JsonElement;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/KeyProperty.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/KeyProperty.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.property;
 
 import com.google.gson.JsonElement;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/Property.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/Property.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.property;
 
 import com.google.gson.JsonElement;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/State.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/State.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.property;
 
 import org.jetbrains.annotations.NotNull;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/UuidProperty.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/UuidProperty.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.property;
 
 import com.google.gson.JsonElement;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/VOCoreProperties.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/property/VOCoreProperties.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.property;
 
 import com.guy7cc.voxelodyssey.core.VOCorePlugin;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/region/AABB.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/region/AABB.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.region;
 
 import org.bukkit.util.Vector;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/region/RegionContext.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/region/RegionContext.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.region;
 
 import java.util.HashSet;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/region/RegionGraph.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/region/RegionGraph.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.region;
 
 import java.util.*;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/region/RegionHandler.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/region/RegionHandler.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.region;
 
 import com.guy7cc.voxelodyssey.core.entity.player.VOPlayer;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/region/RegionManager.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/region/RegionManager.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.region;
 
 import com.guy7cc.voxelodyssey.core.common.Tickable;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/region/RegionShape.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/region/RegionShape.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.region;
 
 import org.bukkit.util.Vector;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/region/Sphere.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/region/Sphere.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.region;
 
 import com.google.common.base.Preconditions;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/region/UniversalRegionShape.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/region/UniversalRegionShape.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.region;
 
 import org.bukkit.util.Vector;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/registry/AbstractRegistryObject.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/registry/AbstractRegistryObject.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.registry;
 
 public abstract class AbstractRegistryObject implements RegistryObject {

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/registry/BuiltInRegistryTypes.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/registry/BuiltInRegistryTypes.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.registry;
 
 import com.guy7cc.voxelodyssey.core.entity.VOEntityType;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/registry/IndexedKey.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/registry/IndexedKey.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.registry;
 
 import com.google.gson.JsonElement;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/registry/Key.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/registry/Key.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.registry;
 
 import com.google.gson.JsonElement;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/registry/Keyed.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/registry/Keyed.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.registry;
 
 public interface Keyed {

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/registry/Registry.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/registry/Registry.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.registry;
 
 import org.bukkit.NamespacedKey;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/registry/RegistryManager.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/registry/RegistryManager.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.registry;
 
 import com.guy7cc.voxelodyssey.core.common.ExecutionOrder;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/registry/RegistryObject.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/registry/RegistryObject.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.registry;
 
 public interface RegistryObject extends Keyed {

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/registry/RegistryType.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/registry/RegistryType.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.registry;
 
 import java.util.Objects;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/util/LogUtil.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/util/LogUtil.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.util;
 
 import java.io.PrintWriter;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/util/RandomUtil.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/util/RandomUtil.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.util;
 
 import com.guy7cc.voxelodyssey.core.registry.Key;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/util/ReflectionUtil.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/util/ReflectionUtil.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.util;
 
 import java.lang.reflect.Field;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/util/StringUtil.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/util/StringUtil.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.util;
 
 import java.util.ArrayList;

--- a/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/util/TranslationUtil.java
+++ b/vo-core/src/main/java/com/guy7cc/voxelodyssey/core/util/TranslationUtil.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.util;
 
 import com.guy7cc.voxelodyssey.core.VoxelOdysseyCore;

--- a/vo-core/src/main/resources/plugin.yml
+++ b/vo-core/src/main/resources/plugin.yml
@@ -1,3 +1,22 @@
+#
+# Copyright (C) 2025 TeamVoxelOdyssey
+#
+# This file is part of VoxelOdysseyPlugins.
+#
+# VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+#
+
 name: VoxelOdysseyCore
 version: '1.0.0'
 main: com.guy7cc.voxelodyssey.core.VOCorePlugin

--- a/vo-core/src/test/java/com/guy7cc/voxelodyssey/core/registry/KeyTest.java
+++ b/vo-core/src/test/java/com/guy7cc/voxelodyssey/core/registry/KeyTest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.core.registry;
 
 import com.guy7cc.voxelodyssey.core.VoxelOdysseyCore;

--- a/vo-plugin/build.gradle.kts
+++ b/vo-plugin/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("java")
     id("io.papermc.paperweight.userdev") version "2.0.0-beta.16"
+    id("com.github.hierynomus.license") version "0.16.1"
 }
 
 group = "com.guy7cc"
@@ -30,6 +31,13 @@ java {
     if (JavaVersion.current() < JavaVersion.toVersion(targetJavaVersion)) {
         toolchain.languageVersion.set(JavaLanguageVersion.of(targetJavaVersion))
     }
+}
+
+license {
+    header = file("$rootDir/config/license/header.txt")
+    exclude("**/*")
+    include("**/*.java")
+    mapping("java", "SLASHSTAR_STYLE")
 }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/VOPlugin.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/VOPlugin.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game;
 
 import com.guy7cc.voxelodyssey.core.VoxelOdysseyCore;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/entity/VODamageNotifiable.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/entity/VODamageNotifiable.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.entity;
 
 import com.guy7cc.voxelodyssey.core.VoxelOdysseyCore;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/entity/VODamageNum.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/entity/VODamageNum.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.entity;
 
 import com.guy7cc.voxelodyssey.core.common.Tickable;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/entity/VODamageable.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/entity/VODamageable.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.entity;
 
 import com.guy7cc.voxelodyssey.core.entity.VOEntity;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/entity/VOEntityTypes.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/entity/VOEntityTypes.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.entity;
 
 import com.guy7cc.voxelodyssey.core.VOCorePlugin;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/entity/player/VOPlayerImpl.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/entity/player/VOPlayerImpl.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.entity.player;
 
 import com.destroystokyo.paper.event.player.PlayerPostRespawnEvent;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/item/ModifierProvider.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/item/ModifierProvider.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.item;
 
 import com.guy7cc.voxelodyssey.core.item.VOItemStackWrapper;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/item/VOItems.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/item/VOItems.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.item;
 
 import com.guy7cc.voxelodyssey.core.item.VOCoreItems;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/property/VOProperties.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/property/VOProperties.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.property;
 
 import com.guy7cc.voxelodyssey.core.property.Property;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/registry/VORegistryTypes.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/registry/VORegistryTypes.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.registry;
 
 import com.guy7cc.voxelodyssey.core.registry.Key;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/VOElement.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/VOElement.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.system;
 
 public enum VOElement {

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/VOElementalVector.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/VOElementalVector.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.system;
 
 import com.google.gson.JsonArray;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/VOElementalVectorProperty.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/VOElementalVectorProperty.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.system;
 
 import com.google.gson.JsonArray;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/Damage.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/Damage.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.system.effect;
 
 import com.guy7cc.voxelodyssey.core.property.ImmutableValueHolder;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/Debuff.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/Debuff.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.system.effect;
 
 import com.guy7cc.voxelodyssey.core.property.ImmutableValueHolder;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/ElementalDamage.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/ElementalDamage.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.system.effect;
 
 import com.guy7cc.voxelodyssey.core.property.VOCoreProperties;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/FieldDamage.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/FieldDamage.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.system.effect;
 
 import com.guy7cc.voxelodyssey.core.property.VOCoreProperties;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/NoneEffect.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/NoneEffect.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.system.effect;
 
 import com.guy7cc.voxelodyssey.core.common.Copyable;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/VOEffect.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/VOEffect.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.system.effect;
 
 import com.guy7cc.voxelodyssey.core.common.Copyable;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/VOEffectApplicable.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/VOEffectApplicable.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.system.effect;
 
 import com.guy7cc.voxelodyssey.core.VoxelOdysseyCore;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/VOEffectPipeline.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/VOEffectPipeline.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.system.effect;
 
 import com.google.gson.JsonArray;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/VOEffectRouter.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/VOEffectRouter.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.system.effect;
 
 import com.google.gson.JsonElement;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/VOEffectSender.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/VOEffectSender.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.system.effect;
 
 import java.util.Collection;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/VOEffectState.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/VOEffectState.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.system.effect;
 
 import com.google.gson.JsonElement;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/VOEffects.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/VOEffects.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.system.effect;
 
 import com.guy7cc.voxelodyssey.core.common.Copyable;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/VOModifierState.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/effect/VOModifierState.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.system.effect;
 
 import com.google.gson.JsonElement;

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/quest/Field.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/quest/Field.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.system.quest;
 
 public class Field {

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/quest/FieldModifier.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/quest/FieldModifier.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.system.quest;
 
 public interface FieldModifier {

--- a/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/quest/Quest.java
+++ b/vo-plugin/src/main/java/com/guy7cc/voxelodyssey/game/system/quest/Quest.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.game.system.quest;
 
 import com.guy7cc.voxelodyssey.core.registry.AbstractRegistryObject;

--- a/vo-plugin/src/main/resources/plugin.yml
+++ b/vo-plugin/src/main/resources/plugin.yml
@@ -1,3 +1,22 @@
+#
+# Copyright (C) 2025 TeamVoxelOdyssey
+#
+# This file is part of VoxelOdysseyPlugins.
+#
+# VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+#
+
 name: VoxelOdyssey
 version: '1.0.0'
 main: com.guy7cc.voxelodyssey.game.VOPlugin

--- a/vodev-plugin/build.gradle.kts
+++ b/vodev-plugin/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("java")
+    id("com.github.hierynomus.license") version "0.16.1"
 }
 
 group = "com.guy7cc"
@@ -31,6 +32,13 @@ java {
     if (JavaVersion.current() < JavaVersion.toVersion(targetJavaVersion)) {
         toolchain.languageVersion.set(JavaLanguageVersion.of(targetJavaVersion))
     }
+}
+
+license {
+    header = file("$rootDir/config/license/header.txt")
+    exclude("**/*")
+    include("**/*.java")
+    mapping("java", "SLASHSTAR_STYLE")
 }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/VODevPlugin.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/VODevPlugin.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev;
 
 import com.guy7cc.voxelodyssey.core.VoxelOdysseyCore;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/VoxelOdysseyDeveloperTools.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/VoxelOdysseyDeveloperTools.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev;
 
 import com.guy7cc.voxelodyssey.core.VoxelOdysseyCore;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/banner/BannerFactory.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/banner/BannerFactory.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.banner;
 
 import com.guy7cc.voxelodyssey.core.registry.AbstractRegistryObject;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/banner/Banners.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/banner/Banners.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.banner;
 
 import com.guy7cc.voxelodyssey.core.registry.Key;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/command/VODevBannerCommand.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/command/VODevBannerCommand.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.command;
 
 import com.guy7cc.voxelodyssey.core.VoxelOdysseyCore;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/command/VODevCommand.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/command/VODevCommand.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.command;
 
 import com.guy7cc.voxelodyssey.core.command.CommandDescriptor;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/command/VODevHatCommand.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/command/VODevHatCommand.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.command;
 
 import com.guy7cc.voxelodyssey.core.command.CommandDescriptor;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/landmark/Landmark.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/landmark/Landmark.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.landmark;
 
 import com.google.gson.JsonElement;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/landmark/LandmarkManager.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/landmark/LandmarkManager.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.landmark;
 
 import com.google.gson.JsonElement;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/landmark/Landmarks.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/landmark/Landmarks.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.landmark;
 
 import org.bukkit.Bukkit;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/registry/VODevRegistryTypes.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/registry/VODevRegistryTypes.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.registry;
 
 import com.guy7cc.voxelodyssey.core.entity.VOEntityType;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/TerrainPresets.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/TerrainPresets.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.tool;
 
 import com.sk89q.worldedit.world.block.BlockType;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/Tool.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/Tool.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.tool;
 
 import org.bukkit.Location;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/ToolManager.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/ToolManager.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.tool;
 
 import org.bukkit.Material;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/impl/DesertMountain.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/impl/DesertMountain.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.tool.impl;
 
 import com.guy7cc.voxelodyssey.dev.tool.Tool;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/impl/ExtendBottom.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/impl/ExtendBottom.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.tool.impl;
 
 import com.guy7cc.voxelodyssey.dev.tool.Tool;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/impl/FillBlank.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/impl/FillBlank.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.tool.impl;
 
 import com.guy7cc.voxelodyssey.dev.tool.Tool;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/impl/ScrapeOff.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/impl/ScrapeOff.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.tool.impl;
 
 import com.guy7cc.voxelodyssey.dev.tool.Tool;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/impl/Smooth.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/impl/Smooth.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.tool.impl;
 
 import com.guy7cc.voxelodyssey.dev.tool.Tool;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/impl/Terrain.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/impl/Terrain.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.tool.impl;
 
 import com.guy7cc.voxelodyssey.dev.tool.Tool;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/impl/TerrainNoDestruction.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/impl/TerrainNoDestruction.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.tool.impl;
 
 import com.guy7cc.voxelodyssey.dev.tool.Tool;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/weight/GaussianDistribution.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/weight/GaussianDistribution.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.tool.weight;
 
 public class GaussianDistribution implements Kernel<Float> {

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/weight/HeightMap.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/weight/HeightMap.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.tool.weight;
 
 public class HeightMap extends KernelImpl<Float> {

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/weight/Kernel.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/weight/Kernel.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.tool.weight;
 
 public interface Kernel<T> {

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/weight/KernelImpl.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/weight/KernelImpl.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.tool.weight;
 
 public class KernelImpl<T> implements Kernel<T> {

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/weight/Kernels.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/weight/Kernels.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.tool.weight;
 
 import java.util.HashMap;

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/weight/MovingAverage.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/tool/weight/MovingAverage.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.tool.weight;
 
 public class MovingAverage implements Kernel<Float> {

--- a/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/util/TerrainUtil.java
+++ b/vodev-plugin/src/main/java/com/guy7cc/voxelodyssey/dev/util/TerrainUtil.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2025 TeamVoxelOdyssey
+ *
+ * This file is part of VoxelOdysseyPlugins.
+ *
+ * VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+ */
 package com.guy7cc.voxelodyssey.dev.util;
 
 import com.sk89q.worldedit.EditSession;

--- a/vodev-plugin/src/main/resources/plugin.yml
+++ b/vodev-plugin/src/main/resources/plugin.yml
@@ -1,3 +1,22 @@
+#
+# Copyright (C) 2025 TeamVoxelOdyssey
+#
+# This file is part of VoxelOdysseyPlugins.
+#
+# VoxelOdysseyPlugins is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# VoxelOdysseyPlugins is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with VoxelOdysseyPlugins. If not, see <https://www.gnu.org/licenses/>.
+#
+
 name: VoxelOdysseyDeveloperTools
 version: '1.0.0'
 main: com.guy7cc.voxelodyssey.dev.VODevPlugin


### PR DESCRIPTION
Gradleプラグインを新たに導入し、ライセンスヘッダをファイルとして用意してそれを全ファイルに適用した。